### PR TITLE
Keep gradient background and lighten fonts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,10 @@
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   margin: 0;
   padding: 0;
   text-align: center;
+  background: var(--primary-bg);
+  color: #f0f0f0;
 }
 
 .hero {
@@ -12,7 +14,7 @@ body {
   justify-content: center;
   align-items: center;
   position: relative;
-  background: var(--primary-bg);
+  background: transparent;
 }
 
 .panel {
@@ -21,11 +23,11 @@ body {
   align-items: center;
   justify-content: center;
   padding: 4rem 2rem;
-  background: #fff;
+  background: transparent;
 }
 
 .panel:nth-of-type(even) {
-  background: #f7f7f7;
+  background: transparent;
 }
 
 .panel .content {
@@ -39,17 +41,19 @@ body {
 .panel .text {
   flex: 1;
   text-align: left;
-  color: #111;
+  color: #f0f0f0;
 }
 
 .panel .text h2 {
   margin-top: 0;
   font-size: 2rem;
+  color: #fff;
 }
 
 .panel .text p {
   font-size: 1.125rem;
   line-height: 1.6;
+  color: #f0f0f0;
 }
 
 .panel .image {
@@ -64,7 +68,7 @@ body {
 }
 
 .panel-cta {
-  background: #fafafa;
+  background: transparent;
 }
 
 .panel-cta .inner {
@@ -75,14 +79,14 @@ body {
   display: inline-block;
   margin-top: 1rem;
   padding: 0.75rem 1.5rem;
-  background: #446AFF;
-  color: #fff;
+  background: #fff;
+  color: #446AFF;
   text-decoration: none;
   border-radius: 4px;
 }
 
 .cta-button:hover {
-  background: #3655cc;
+  background: #e0e0e0;
 }
 
 @media (max-width: 768px) {

--- a/index.html
+++ b/index.html
@@ -3,13 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>GymMeet Pro — Coming Soon</title>
-  <style>
-    :root {
-      --primary-bg: linear-gradient(135deg, #8622FF, #446AFF);
-      --heading-color: #fff;
-      --text-color: #eee;
-    }
+    <title>GymMeet Pro — Coming Soon</title>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+      :root {
+        --primary-bg: linear-gradient(135deg, #8622FF, #446AFF);
+        --heading-color: #fff;
+        --text-color: #f0f0f0;
+      }
 
     .container {
       padding: 2rem;


### PR DESCRIPTION
## Summary
- keep gradient background persistent across all sections
- adopt light fonts and colors, including a white CTA button, for improved contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890380c8e488330ae2f80d811c58bea