### PR TITLE
Add contact call to action and relocate copyright

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -75,6 +75,14 @@ body {
   text-align: center;
 }
 
+.panel-contact {
+  background: transparent;
+}
+
+.panel-contact .inner {
+  text-align: center;
+}
+
 .cta-button {
   display: inline-block;
   margin-top: 1rem;

--- a/index.html
+++ b/index.html
@@ -37,9 +37,7 @@
     }
 
     footer {
-      position: absolute;
-      bottom: 1rem;
-      width: 100%;
+      margin-top: 2rem;
       font-size: 0.9rem;
       color: rgba(255, 255, 255, 0.4);
     }
@@ -67,7 +65,6 @@
       <h1>GymMeet Pro</h1>
       <p>The modern platform for managing gymnastics meets — built for directors, coaches, and parents. Launching soon.</p>
     </div>
-    <footer>© 2025 Gymnastics Technology Partners LLC</footer>
   </section>
 
   <section class="panel panel-setup">
@@ -146,6 +143,13 @@
     <div class="inner">
       <h2>Ready to Simplify Your Season?</h2>
       <a href="https://gymmeet.pro/demo" class="cta-button" aria-label="Schedule a demo">Schedule a Demo</a>
+    </div>
+  </section>
+
+  <section class="panel panel-contact">
+    <div class="inner">
+      <p>For information on how your gymnastics team can start modernizing its meet management today, contact <a href="mailto:chris@gymtechpartners.com">chris@gymtechpartners.com</a>.</p>
+      <footer>© 2025 Gymnastics Technology Partners LLC</footer>
     </div>
   </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -158,8 +158,18 @@ gsap.from('.panel-ai .text', {
   }
 });
 
+gsap.from('.panel-contact .inner', {
+  opacity: 0,
+  y: 50,
+  duration: 1,
+  scrollTrigger: {
+    trigger: '.panel-contact',
+    start: 'top 80%'
+  }
+});
+
 ScrollTrigger.create({
-  trigger: '.panel-cta',
+  trigger: '.panel-contact',
   start: 'top bottom',
   pin: true,
   pinSpacing: false


### PR DESCRIPTION
## Summary
- add final contact section with email for modernization inquiries
- move existing copyright message to the page's end
- include styling and scroll animation for new section

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894c292d7d88330857026b787408ecc